### PR TITLE
Devide conponents Content

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,9 +1,15 @@
 <template>
-  <div class="gt-article" v-html="articleObject.html" />
+  <Content>
+    <div class="gt-article" v-html="articleObject.html" />
+  </Content>
 </template>
 
 <script>
+import Content from '~/components/Content.vue'
 export default {
+  components:{
+    Content
+    },
   props: {
     articleId: String,
     articleObject: Object
@@ -13,19 +19,6 @@ export default {
 </script>
 
 <style>
-.gt-article{
-  max-width: 800px;
-  word-wrap: break-word;
-  margin: auto;
-  padding: 1em;
-  background-color: #ffffff;
-  border: solid;
-  border-radius: 0.2em;
-  border-width: 1px;
-  border-color: #aaaaaa;
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
 img{
   width: 90%;
   display: block;

--- a/components/Content.vue
+++ b/components/Content.vue
@@ -1,0 +1,46 @@
+<template>
+    <div :class="{
+      'gt-content':true,
+      'gt-content-header-navigation':isHeaderNavigation,
+      'gt-content-non-header-navigation': !isHeaderNavigation
+      }">
+        <slot></slot>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        isHeaderNavigation : false
+    }
+}
+</script>
+
+<style>
+.gt-content{
+  max-width: 800px;
+  word-wrap: break-word;
+  margin: auto;
+  background-color: #ffffff;
+  border: solid;
+  border-radius: 0.2em;
+  border-width: 1px;
+  border-color: #aaaaaa;
+  margin-bottom: 1em;
+}
+.gt-content-header-navigation{
+  margin-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-top-style: none;
+  text-align: center;
+  padding: 0.1em;
+  padding-bottom: 0.2m;
+  font-size: 1.3em;
+}
+.gt-content-non-header-navigation{
+  margin-top: 1em;
+  padding: 1em;
+}
+
+</style>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -2,17 +2,20 @@
   <div class="gt-header">
     Green Turtle
   </div>
-  <div class="gt-header-navigation">
-    <a href="https://blog.yammer.fun">Home</a>
-    <a href="https://blog.yammer.fun/article/aboutMe">About</a>
-    <a href="https://twitter.com/basd4g">Twitter</a>
-    <a href="https://github.com/basd4g">GitHub</a>
-  </div>
+  <Content :is-header-navigation="true">
+    <a class="gt-header-navigation-item" href="https://blog.yammer.fun">Home</a>
+    <a class="gt-header-navigation-item" href="https://blog.yammer.fun/article/aboutMe">About</a>
+    <a class="gt-header-navigation-item" href="https://twitter.com/basd4g">Twitter</a>
+    <a class="gt-header-navigation-item" href="https://github.com/basd4g">GitHub</a>
+  </Content>
 </div></template>
 
 <script>
+import Content from '~/components/Content.vue'
 export default {
-    
+    components:{
+      Content
+    }
 }
 </script>
 
@@ -26,28 +29,8 @@ export default {
     color: #ffffff;
     background-color: #35495e;
 }
-.gt-header-navigation{
-  max-width: 800px;
-  word-wrap: break-word;
-  margin: auto;
-  padding: 1em;
-  background-color: #ffffff;
-  border: solid;
-  border-radius: 0.2em;
-  border-width: 1px;
-  border-color: #aaaaaa;
-  margin-top: 1em;
-  margin-bottom: 1em;
-  margin-top: 0;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    border-top-style: none;
-    text-align: center;
-    padding: 0.1em;
-    padding-bottom: 0.2m;
-    font-size: 1.3em;
-}
-.gt-header-navigation a {
+
+.gt-header-navigation-item {
   color:inherit;
   text-decoration:none;
   background-color: #ffffff;
@@ -59,13 +42,13 @@ export default {
   border-left-style: solid;
   border-left-color: #aaaaaa;
   border-left-width: 1px;
-    font-size: 1.0em;
-    display: inline-block;
-    margin: auto;
-    width: 20%;
-    max-width: 190px;
-    margin-top: 0.1em;
-    margin-bottom: 0.1em;
-  
+  font-size: 1.0em;
+  display: inline-block;
+  margin: auto;
+  width: 20%;
+  max-width: 190px;
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
ページ中央部の主要コンテンツを表示する部分をContentsコンポーネントに切り出し。
再利用性を上げた。
このプルリク時点で、ヘッダーナビゲーションと、記事ページの記事本文に利用している。

このあともトップページの記事省略表示などに使う予定